### PR TITLE
[기능추가] 배달의 민족같은 사이렌 홈 페이지 틀 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import PaymentPage from './components/PaymentPage';
 import KioskSelectionPage from './components/KioskSelectionPage';
 import GuardPage from './components/GuardPage';
 import OrderCompleteCheck from "./components/admin/OrderCompleteCheck";
+import SirenHomePage from "./components/siren/SirenHomePage";
 
 const App: React.FC = () => {
     const [isHighContrast, setIsHighContrast] = useState(false);
@@ -26,6 +27,8 @@ const App: React.FC = () => {
                     <Route path="/guard" element={<GuardPage />} />
                     <Route path="/admin/orderComplete" element={<OrderCompleteCheck />} />
                     <Route path="*" element={<Navigate to="/users/login" />} />
+                {/*    사이렌 페이지 라우트*/}
+                    <Route path="/siren" element={<SirenHomePage />}/>
                 </Routes>
             </ThemeProvider>
         </AuthProvider>

--- a/src/components/menu/Header.tsx
+++ b/src/components/menu/Header.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import AdminLoginModal from '../admin/modals/AdminLoginModal';
 import styled from 'styled-components';
+import {CrossIcon} from "react-select/dist/declarations/src/components/indicators";
+import {Button} from "../style/PaymentPageStyles";
 
 const HeaderWrapper = styled.header`
     grid-area: header;
@@ -37,12 +39,18 @@ const Header: React.FC = () => {
         navigate('/guard');
     };
 
+    const handleSirenHomePage = () => {
+        navigate('/siren');
+    }
+
     return (
         <HeaderWrapper>
             <HomeIcon onClick={handleMainPage}>🏠</HomeIcon>
             <h1>Easy KIOSK</h1>
             <SettingsIcon onClick={handleAdminClick}>⚙️</SettingsIcon>
             {isAdminLoginOpen && <AdminLoginModal onClose={handleAdminLoginClose} />}
+            {/* 사이렌 테스트 버튼 */}
+            <Button onClick={handleSirenHomePage}>사이렌</Button>
         </HeaderWrapper>
     );
 }

--- a/src/components/siren/SirenHomePage.tsx
+++ b/src/components/siren/SirenHomePage.tsx
@@ -39,6 +39,8 @@ const SirenHomePage: React.FC = () => {
                 <Title>AIKiosk</Title>
                 <UserSection>
                     <p>최현철 님</p>
+                    {/* TO DO : 유저정보 스프링에서 가져오기*/}
+                    {/* TO DO : 로그아웃 상태에서는 로그인 버튼으로 변경해야함 */}
                     <svg xmlns="http://www.w3.org/2000/svg" width="41" height="34" viewBox="0 0 41 34" fill="none">
                         <path
                             d="M39.5 17C39.5 25.3098 31.2685 32.5 20.5 32.5C9.73151 32.5 1.5 25.3098 1.5 17C1.5 8.69019 9.73151 1.5 20.5 1.5C31.2685 1.5 39.5 8.69019 39.5 17Z"
@@ -48,7 +50,8 @@ const SirenHomePage: React.FC = () => {
                     </svg>
                 </UserSection>
             </Header>
-            {/*LocationSection 클릭시 지역 선택 지도로 이동*/}
+            {/* TO DO??? : LocationSection 클릭시 지역 선택 지도로 이동???*/}
+            {/*    없으면 좀 뭐해서 배민처럼 넣어봣음 */}
             <LocationSection>
                 <LocationIcon>
                     <svg xmlns="http://www.w3.org/2000/svg" width="34" height="24" viewBox="0 0 34 24" fill="none">
@@ -60,9 +63,12 @@ const SirenHomePage: React.FC = () => {
                     </svg>
                 </LocationIcon>
                 <LocationText>노원구 공릉동 삼육대학교 시온관</LocationText>
+            {/*    (사용자가 위치한) 선택한 지역 표시 */}
             </LocationSection>
             <MainContent>
                 <StoreListContainer>
+                    {/* 스프링에서 점포 정보 가져오기 */}
+
                     {/*{stores.map((store) => (*/}
                     {/*    <StoreCard key={store.id}>*/}
                     {/*        <StoreImage src={store.imageUrl} alt={store.name} />*/}
@@ -72,6 +78,8 @@ const SirenHomePage: React.FC = () => {
                     {/*        </StoreInfo>*/}
                     {/*    </StoreCard>*/}
                     {/*))}*/}
+
+                    {/* 카드 클릭시 해당 키오스크로 이동 */}
                     <StoreCard>
                         <StoreImage/>
                         <StoreInfo>

--- a/src/components/siren/SirenHomePage.tsx
+++ b/src/components/siren/SirenHomePage.tsx
@@ -1,0 +1,151 @@
+import React, {useEffect, useState} from 'react';
+import axios from 'axios';
+import {
+    Container,
+    Header,
+    Title,
+    UserSection,
+    LocationSection,
+    LocationText,
+    LocationIcon,
+    MainContent,
+    StoreListContainer,
+    StoreCard,
+    StoreImage,
+    StoreInfo,
+    StoreLocation,
+    StoreName,
+} from '../style/siren/HomeStyles';
+
+interface Store {
+    id: number;
+    name: string;
+    location: string;
+    imageUrl: string;
+}
+
+const SirenHomePage: React.FC = () => {
+    const [stores, setStores] = useState<Store[]>([]);
+
+    useEffect(() => {
+        axios.get('/api/stores') // API 호출 부분
+            .then(response => setStores(response.data))
+            .catch(error => console.error('Error fetching stores:', error));
+    }, []);
+
+    return (
+        <Container>
+            <Header>
+                <Title>AIKiosk</Title>
+                <UserSection>
+                    <p>최현철 님</p>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="41" height="34" viewBox="0 0 41 34" fill="none">
+                        <path
+                            d="M39.5 17C39.5 25.3098 31.2685 32.5 20.5 32.5C9.73151 32.5 1.5 25.3098 1.5 17C1.5 8.69019 9.73151 1.5 20.5 1.5C31.2685 1.5 39.5 8.69019 39.5 17Z"
+                            stroke="white" strokeWidth="3"/>
+                        <circle cx="20.5" cy="11.5" r="5.5" fill="white"/>
+                        <ellipse cx="20.5" cy="25.5" rx="10.5" ry="8.5" fill="white"/>
+                    </svg>
+                </UserSection>
+            </Header>
+            {/*LocationSection 클릭시 지역 선택 지도로 이동*/}
+            <LocationSection>
+                <LocationIcon>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="34" height="24" viewBox="0 0 34 24" fill="none">
+                        <path
+                            d="M29.75 13V20C29.75 20.5523 29.1158 21 28.3333 21H5.66667C4.88426 21 4.25 20.5523 4.25 20V4C4.25 3.44771 4.88426 3 5.66667 3H15.5833"
+                            stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                        <path d="M9.91666 13.3599V17H15.0997L29.75 6.65405L24.5757 3L9.91666 13.3599Z" fill="white"
+                              stroke="#FFC5AE" strokeWidth="2" strokeLinejoin="round"/>
+                    </svg>
+                </LocationIcon>
+                <LocationText>노원구 공릉동 삼육대학교 시온관</LocationText>
+            </LocationSection>
+            <MainContent>
+                <StoreListContainer>
+                    {/*{stores.map((store) => (*/}
+                    {/*    <StoreCard key={store.id}>*/}
+                    {/*        <StoreImage src={store.imageUrl} alt={store.name} />*/}
+                    {/*        <StoreInfo>*/}
+                    {/*            <StoreLocation>{store.location}</StoreLocation>*/}
+                    {/*            <StoreName>{store.name}</StoreName>*/}
+                    {/*        </StoreInfo>*/}
+                    {/*    </StoreCard>*/}
+                    {/*))}*/}
+                    <StoreCard>
+                        <StoreImage/>
+                        <StoreInfo>
+                            <StoreLocation>서울시 서초구</StoreLocation>
+                            <StoreName>깐부치킨</StoreName>
+                        </StoreInfo>
+                    </StoreCard>
+                    <StoreCard>
+                        <StoreImage/>
+                        <StoreInfo>
+                            <StoreLocation>서울시 서초구</StoreLocation>
+                            <StoreName>깐부치킨</StoreName>
+                        </StoreInfo>
+                    </StoreCard>
+                    <StoreCard>
+                        <StoreImage/>
+                        <StoreInfo>
+                            <StoreLocation>서울시 서초구</StoreLocation>
+                            <StoreName>깐부치킨</StoreName>
+                        </StoreInfo>
+                    </StoreCard>
+                    <StoreCard>
+                        <StoreImage/>
+                        <StoreInfo>
+                            <StoreLocation>서울시 서초구</StoreLocation>
+                            <StoreName>깐부치킨</StoreName>
+                        </StoreInfo>
+                    </StoreCard>
+                    <StoreCard>
+                        <StoreImage/>
+                        <StoreInfo>
+                            <StoreLocation>서울시 서초구</StoreLocation>
+                            <StoreName>깐부치킨</StoreName>
+                        </StoreInfo>
+                    </StoreCard>
+                    <StoreCard>
+                        <StoreImage/>
+                        <StoreInfo>
+                            <StoreLocation>서울시 서초구</StoreLocation>
+                            <StoreName>깐부치킨</StoreName>
+                        </StoreInfo>
+                    </StoreCard>
+                    <StoreCard>
+                        <StoreImage/>
+                        <StoreInfo>
+                            <StoreLocation>서울시 서초구</StoreLocation>
+                            <StoreName>깐부치킨</StoreName>
+                        </StoreInfo>
+                    </StoreCard>
+                    <StoreCard>
+                        <StoreImage/>
+                        <StoreInfo>
+                            <StoreLocation>서울시 서초구</StoreLocation>
+                            <StoreName>깐부치킨</StoreName>
+                        </StoreInfo>
+                    </StoreCard>
+                    <StoreCard>
+                        <StoreImage/>
+                        <StoreInfo>
+                            <StoreLocation>서울시 서초구</StoreLocation>
+                            <StoreName>깐부치킨</StoreName>
+                        </StoreInfo>
+                    </StoreCard>
+                    <StoreCard>
+                        <StoreImage/>
+                        <StoreInfo>
+                            <StoreLocation>서울시 서초구</StoreLocation>
+                            <StoreName>깐부치킨</StoreName>
+                        </StoreInfo>
+                    </StoreCard>
+                </StoreListContainer>
+            </MainContent>
+        </Container>
+    );
+};
+
+export default SirenHomePage;

--- a/src/components/style/siren/HomeStyles.ts
+++ b/src/components/style/siren/HomeStyles.ts
@@ -1,0 +1,165 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+    width: 100vw;
+    height: 100vh;
+    background-color: #FFCEBA;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    overflow-x: hidden;
+`;
+
+export const Header = styled.header`
+    width: 100%;
+    height: 60px;
+    background-color: #E05721;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 20px;
+`;
+
+export const Title = styled.h1`
+    padding-left : 4.5rem;
+    font-style: italic;
+    font-weight: bold;
+    color: white;
+`;
+
+export const UserSection = styled.div`
+    display: flex;
+    align-items: center;
+    color: white;
+    white-space: nowrap; /* 텍스트가 줄 바꿈 없이 한 줄로 표시되도록 설정 */
+    padding-right : 3rem;
+    @media (max-width: 768px) {
+        margin-right: -2%;
+    }
+
+    p {
+        padding-left: 4rem;
+        padding-right: 1rem;
+        font-size: 1.8rem;
+
+        @media (max-width: 768px) {
+            padding-right: 0rem;
+            padding-left: 0rem;
+            margin-right: 0.5rem;
+            font-size: 1.5rem; /* 작은 화면에서 텍스트 크기를 줄임 */
+        }
+    }
+
+    svg {
+        width: 50px;  /* 고정된 크기로 설정 */
+        height: 50px; /* 고정된 크기로 설정 */
+        @media (max-width: 768px) {
+            font-size: 1.5rem; /* 작은 화면에서 텍스트 크기를 줄임 */
+        }
+    }
+`;
+
+
+
+export const LocationSection = styled.div`
+    width: 100%;
+    height: 7%;
+    background-color: #FF7D3C;
+    display: flex;
+    align-items: center;
+    padding-left: 4%;
+`;
+
+export const LocationIcon = styled.div`
+    margin-right: 1%;
+
+    svg {
+        margin-top:20%;
+        width: 100%;
+        height: 20%;
+    }
+`;
+
+export const LocationText = styled.div`
+    color: white;
+    font-weight: bold;
+    font-style: italic;
+    font-size: 1.5rem;
+    text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.27);
+`;
+
+export const MainContent = styled.div`
+    width: 90%;
+    background-color: #ffffff;
+    border-radius: 16px;
+    margin-top: 20px;
+    padding: 20px;
+    flex-grow: 1;
+    overflow-x: auto;
+    overflow-y: scroll; /* 세로 스크롤 가능 */
+    overflow-x: hidden; /* 가로 스크롤 숨김 */
+
+    /* 스크롤바 숨기기 (웹킷 기반 브라우저) */
+    ::-webkit-scrollbar {
+        width: 0;  /* 세로 스크롤바 숨기기 */
+        height: 0; /* 가로 스크롤바 숨기기 */
+    }
+
+    /* Firefox에서 스크롤바 숨기기 */
+    scrollbar-width: none; /* Firefox에서 스크롤바 숨기기 */
+    -ms-overflow-style: none;  /* IE 10+에서 스크롤바 숨기기 */
+    margin-bottom: 10px;
+`;
+
+export const StoreListContainer = styled.div`
+    display: grid;
+    grid-template-columns: repeat(3, 1fr); /* 3열로 고정 */
+    grid-gap: 0.5rem; /* 카드 간의 간격을 줄이기 위해 0.5rem로 설정 */
+    justify-items: center; /* 아이템을 수평으로 가운데 정렬 */
+    padding: 10px;
+    overflow-y: auto;
+`;
+
+export const StoreCard = styled.div`
+    width: 90%;
+    background-color: #FFFFFF;
+    box-shadow: 0px 0px 4px 0px rgba(0, 0, 0, 0.25);
+    border-radius: 16px;
+    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 10px;
+
+    @media (max-width: 768px) {
+        width: 75%; /* 모바일에서도 3개가 들어갈 수 있도록 30%로 설정 */
+        padding: 15px;
+    }
+`;
+
+export const StoreImage = styled.img`
+    width: 100%;
+    height: 120px;
+    border-radius: 12px;
+    object-fit: cover;
+`;
+
+export const StoreInfo = styled.div`
+    width: 100%;
+    padding-top: 10px;
+    text-align: center;
+`;
+
+export const StoreLocation = styled.p`
+    font-size: 0.9rem;
+    color: #555555;
+    margin: 0;
+`;
+
+export const StoreName = styled.h2`
+    font-size: 1rem;
+    color: #333333;
+    margin: 5px 0 0 0;
+    font-weight: bold;
+`;
+


### PR DESCRIPTION
## 설명

### 작업 내용
- 스프링 엔드포인트를 연결하기위한 준비
  1. 엔드포인트 붙여야 하는 부분을 주석 달아놓음
- 모바일 동작을 위한 반응형으로 구현
- 스타일 컴포넌트 활용 
  1. component/styles/siren 으로 만듬
### 기술적 커뮤니케이션
- 더미 데이터를 넣어놨음
- 리액트 부분에서 미구현 된 부분, 스프링 연결 부분은 오늘 안에 끝낼 예정

### 리뷰 참고사항
- 추가된 페이지는 http://localhost:3000/siren 으로 접속 ( 요소들에 대한 onClick은 아직 미구현 )
- ![image](https://github.com/user-attachments/assets/ee5862af-21c1-4e47-bb89-bc4286a583fc)

## 기획 자료 및 작업 배경 (선택 사항)
- 피그마 화면 구상도
![사이렌홈](https://github.com/user-attachments/assets/e3e923de-64e8-4f6a-92db-f018286d510f)


## 체크리스트
- [V] 코드가 정상적으로 작동하는지 확인했습니다.
- [V] 모든 문서를 작성했습니다.
- [V] PR 템플릿의 모든 체크박스를 채웠습니다.